### PR TITLE
Fix-import-path

### DIFF
--- a/WebDAV/WebDAV.go
+++ b/WebDAV/WebDAV.go
@@ -17,8 +17,7 @@ package main
 
 import (
 	"github.com/astaxie/beego"
-
-	"samples/WebDAV/controllers"
+	"github.com/beego/samples/WebDAV/controllers"
 )
 
 func main() {

--- a/WebIM/WebIM.go
+++ b/WebIM/WebIM.go
@@ -18,8 +18,7 @@ package main
 import (
 	"github.com/astaxie/beego"
 	"github.com/beego/i18n"
-
-	"samples/WebIM/controllers"
+	"github.com/beego/samples/WebIM/controllers"
 )
 
 const (

--- a/WebIM/controllers/chatroom.go
+++ b/WebIM/controllers/chatroom.go
@@ -20,8 +20,7 @@ import (
 
 	"github.com/astaxie/beego"
 	"github.com/gorilla/websocket"
-
-	"samples/WebIM/models"
+	"github.com/beego/samples/WebIM/models"
 )
 
 type Subscription struct {

--- a/WebIM/controllers/longpolling.go
+++ b/WebIM/controllers/longpolling.go
@@ -15,7 +15,7 @@
 package controllers
 
 import (
-	"samples/WebIM/models"
+	"github.com/beego/samples/WebIM/models"
 )
 
 // LongPollingController handles long polling requests.

--- a/WebIM/controllers/websocket.go
+++ b/WebIM/controllers/websocket.go
@@ -20,8 +20,7 @@ import (
 
 	"github.com/astaxie/beego"
 	"github.com/gorilla/websocket"
-
-	"samples/WebIM/models"
+	"github.com/beego/samples/WebIM/models"
 )
 
 // WebSocketController handles WebSocket requests.

--- a/shorturl/controllers/short.go
+++ b/shorturl/controllers/short.go
@@ -3,7 +3,7 @@ package controllers
 import (
 	"github.com/astaxie/beego"
 	"github.com/astaxie/beego/cache"
-	"samples/shorturl/models"
+	"github.com/beego/samples/shorturl/models"
 )
 
 var (

--- a/shorturl/main.go
+++ b/shorturl/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/astaxie/beego"
-	"samples/shorturl/controllers"
+	"github.com/beego/samples/shorturl/controllers"
 )
 
 func main() {

--- a/todo/controllers/task.go
+++ b/todo/controllers/task.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 
 	"github.com/astaxie/beego"
-	"samples/todo/models"
+	"github.com/beego/samples/todo/models"
 )
 
 type TaskController struct {

--- a/todo/main.go
+++ b/todo/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/astaxie/beego"
-	"samples/todo/controllers"
+	"github.com/beego/samples/todo/controllers"
 )
 
 func main() {


### PR DESCRIPTION
The go get command import the project to GOROOT/github.com/beego/samples, not to GOROOT/samples

If we get the project with go get command and try to run, it will fail with errors something like below :

2017/07/06 17:54:25 ERROR    ▶ 0003 Failed to build the application: main.go:5:2: cannot find package samples/todo/controllers in any of:
/usr/local/go/src/samples/todo/controllers (from GOROOT )
/home/<username>/<project name>/src/samples/todo/controllers (from GOPATH)
GOROOT/samples is not the right location on idiomatic Go