### PR TITLE
Update chatroom.go

### DIFF
--- a/WebIM/controllers/chatroom.go
+++ b/WebIM/controllers/chatroom.go
@@ -72,7 +72,7 @@ func chatroom() {
 			}
 		case event := <-publish:
 			// Notify waiting list.
-			for ch := waitingList.Back(); ch != nil; ch = ch.Prev() {
+			for ch := waitingList.Back(); ch != nil; ch = waitingList.Front() {
 				ch.Value.(chan bool) <- true
 				waitingList.Remove(ch)
 			}


### PR DESCRIPTION
fixed bug;本来是想要循环遍历所有的长轮询的等待队列，遍历之后删除节点，但是由于循环条件出错，并不能达到预想的情况，而是遗漏了很多的节点。修改如下：