### PR TITLE
修复长轮询等待队列一直堵塞的bug

### DIFF
--- a/WebIM/controllers/chatroom.go
+++ b/WebIM/controllers/chatroom.go
@@ -72,8 +72,10 @@ func chatroom() {
 			}
 		case event := <-publish:
 			// Notify waiting list.
-			for ch := waitingList.Back(); ch != nil; ch = ch.Prev() {
+			var n *list.Element
+			for ch := waitingList.Back(); ch != nil; ch = n {
 				ch.Value.(chan bool) <- true
+				n = ch.Prev()
 				waitingList.Remove(ch)
 			}
 


### PR DESCRIPTION
有消息的时候，给等待队列通道发送true，使其停止堵塞，原文件循环等待队列并清除队列元素写法错误，导致等待队列只循环一次便结束，无法让所有的等待队列结束堵塞状态