### PR TITLE
fix: WebIM HTTPAddr conf: from http server Running on http://:8089 to…

### DIFF
--- a/WebIM/conf/app.conf
+++ b/WebIM/conf/app.conf
@@ -1,3 +1,5 @@
 appname = Web IM
 
 lang_types = en-US|zh-CN
+
+HTTPAddr = localhost


### PR DESCRIPTION
» bee run
_____
| ___ \
| |_/ /  ___   ___
| ___ \ / _ \ / _ \
| |_/ /|  __/|  __/
\____/  \___| \___| v2.0.2
2021/10/26 23:18:58 INFO     ▶ 0001 Using 'WebIM' as 'appname'
2021/10/26 23:18:58 INFO     ▶ 0002 Initializing watcher...
2021/10/26 23:19:00 SUCCESS  ▶ 0003 Built Successfully!
2021/10/26 23:19:00 INFO     ▶ 0004 Restarting 'WebIM'...
2021/10/26 23:19:00 SUCCESS  ▶ 0005 './WebIM' is running...
2021/10/26 23:19:01.388 [D] [app.go:32]  Loading language: en-US 
2021/10/26 23:19:01.388 [D] [app.go:32]  Loading language: zh-CN 
2021/10/26 23:19:01.389 [I] [WebIM.go:29]  Web IM 0.1.1.0227 
2021/10/26 23:19:01.397 [I] [asm_amd64.s:1373]  http server Running on http://:8089

`2021/10/26 23:19:01.397 [I] [asm_amd64.s:1373]  http server Running on http://:8089` is wrong appearance

set config `HTTPAddr = localhost` into app.conf

 then:

2021/10/26 23:31:40.590 [I] [asm_amd64.s:1373]  http server Running on http://localhost:8089
