### PR TITLE
fix: abort handler manually after abnormal closure

### DIFF
--- a/WebIM/controllers/websocket.go
+++ b/WebIM/controllers/websocket.go
@@ -68,6 +68,7 @@ func (this *WebSocketController) Join() {
 	for {
 		_, p, err := ws.ReadMessage()
 		if err != nil {
+			this.Abort("200")
 			return
 		}
 		publish <- newEvent(models.EVENT_MESSAGE, uname, string(p))


### PR DESCRIPTION
i had ran the chatroom example on my local machine, however, when user closed the tab on browser, the handler just crashed with the following logs:

`[panic.go:838]  the request url is  /ws/join

[panic.go:838]  Handler crashed with error can't find templatefile in the path:views/websocketcontroller/join.tpl
`

it seems that `beego` trys to find template and render  after `/ws/join` handler return, which is not neccessary in the case. Instead, abort handler manually is suitable.  